### PR TITLE
Remove 'TX' prefix from arbitrary signing

### DIFF
--- a/app/src/apdu_handler.c
+++ b/app/src/apdu_handler.c
@@ -70,7 +70,7 @@ __Z_INLINE uint8_t convertP1P2(uint8_t p1, const uint8_t p2)
     return 0xFF;
 }
 
-__Z_INLINE bool process_chunk(__Z_UNUSED volatile uint32_t *tx, uint32_t rx)
+__Z_INLINE bool process_chunk(__Z_UNUSED volatile uint32_t *tx, uint32_t rx, bool isTx)
 {
     const uint8_t P1 = G_io_apdu_buffer[OFFSET_P1];
     const uint8_t P2 = G_io_apdu_buffer[OFFSET_P2];
@@ -106,7 +106,10 @@ __Z_INLINE bool process_chunk(__Z_UNUSED volatile uint32_t *tx, uint32_t rx)
                 extractHDPath();
                 accountIdSize = ACCOUNT_ID_LENGTH;
             }
-            tx_append((unsigned char*)tmpBuff, 2);
+
+            if (isTx) {
+                tx_append((unsigned char*)tmpBuff, 2);
+            }
 
             if (rx < (OFFSET_DATA + accountIdSize)) {
                 THROW(APDU_CODE_WRONG_LENGTH);
@@ -148,7 +151,11 @@ __Z_INLINE bool process_chunk(__Z_UNUSED volatile uint32_t *tx, uint32_t rx)
                 extractHDPath();
                 accountIdSize = ACCOUNT_ID_LENGTH;
             }
-            tx_append((unsigned char*)tmpBuff, 2);
+
+            if (isTx) {
+                tx_append((unsigned char*)tmpBuff, 2);
+            }
+
             added = tx_append(&(G_io_apdu_buffer[OFFSET_DATA + accountIdSize]), rx - (OFFSET_DATA + accountIdSize));
             tx_initialized = false;
             if (added != rx - (OFFSET_DATA + accountIdSize)) {
@@ -166,7 +173,7 @@ __Z_INLINE void handle_sign_msgpack(volatile uint32_t *flags, volatile uint32_t 
         tx_group_state_reset();
     }
 
-    if (!process_chunk(tx, rx)) {
+    if (!process_chunk(tx, rx, true)) {
         THROW(APDU_CODE_OK);
     }
 
@@ -234,7 +241,7 @@ __Z_INLINE void handle_get_public_key(volatile uint32_t *flags, volatile uint32_
 
 __Z_INLINE void handle_arbitrary_sign(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx) {
     zemu_log("handle_arbitrary_sign\n");
-    if (!process_chunk(tx, rx)) {
+    if (!process_chunk(tx, rx, false)) {
         THROW(APDU_CODE_OK);
     }
 

--- a/app/src/common/actions.h
+++ b/app/src/common/actions.h
@@ -40,7 +40,7 @@ __Z_INLINE zxerr_t app_fill_address() {
 }
 
 __Z_INLINE void app_sign_arbitrary() {
-    zxerr_t err = crypto_sign((uint8_t *) G_io_apdu_buffer, IO_APDU_BUFFER_SIZE - 3, tx_get_buffer(), TO_SIGN_SIZE + 2); // +2 for the prepended 'TX'
+    zxerr_t err = crypto_sign((uint8_t *) G_io_apdu_buffer, IO_APDU_BUFFER_SIZE - 3, tx_get_buffer(), TO_SIGN_SIZE);
 
     if (err != zxerr_ok) {
         set_code(G_io_apdu_buffer, 0, APDU_CODE_SIGN_VERIFY_ERROR);

--- a/app/src/common/tx.c
+++ b/app/src/common/tx.c
@@ -248,7 +248,7 @@ zxerr_t tx_getItem_arbitrary(int8_t displayIdx, char *outKey, uint16_t outKeyLen
 }
 
 zxerr_t tx_getNumItems_arbitrary(uint8_t *num_items) {
-    char *json = (char *) (tx_get_buffer() + TO_SIGN_SIZE + strlen("TX") + strlen(arbitrary_sign_domain) + 1);
+    char *json = (char *) (tx_get_buffer() + TO_SIGN_SIZE + strlen(arbitrary_sign_domain) + 1);
     int count = 1;
     bool in_string = false;
     
@@ -266,9 +266,9 @@ zxerr_t tx_getNumItems_arbitrary(uint8_t *num_items) {
 
 // JSON parser for maximum of 1 nesting level in JSON
 void tx_parse_arbitrary() {
-    set_arbitrary_sign_domain((char *) (tx_get_buffer() + TO_SIGN_SIZE + strlen("TX")));
+    set_arbitrary_sign_domain((char *) (tx_get_buffer() + TO_SIGN_SIZE));
 
-    char *json = (char *) (tx_get_buffer() + TO_SIGN_SIZE + strlen("TX") + strlen(arbitrary_sign_domain) + 1);
+    char *json = (char *) (tx_get_buffer() + TO_SIGN_SIZE + strlen(arbitrary_sign_domain) + 1);
 
     uint8_t idx = 0;
     while (*json) {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -413,8 +413,6 @@ export default class AlgorandApp {
                   throw new Error('Bad JSON');
               }
 
-              console.log('clientDataJson', clientDataJson)
-
               const canonifiedClientDataJson = canonify(clientDataJson);
               if (!canonifiedClientDataJson) {
                   throw new Error('Bad JSON');
@@ -431,12 +429,12 @@ export default class AlgorandApp {
               if(Buffer.compare(authenticatorData.slice(0, 32), rp_id_hash) !== 0) {
                   throw new Error('Failed Domain Auth');
               }
-              
               const clientDataJsonHash: Buffer = crypto.createHash('sha256').update(canonifiedClientDataJson).digest();
               const authenticatorDataHash: Buffer = crypto.createHash('sha256').update(authenticatorData).digest();
 
               // Concatenate clientDataJsonHash and authenticatorData
               toSign = Buffer.concat([clientDataJsonHash, authenticatorDataHash]);
+
               break;
 
           default:
@@ -468,8 +466,6 @@ export default class AlgorandApp {
       }
       chunks.push(message.slice(i, end));
     }
-
-    console.log('chunks', chunks.map(chunk => chunk.toString('hex')))
 
     let return_code = 0
     let response = Buffer.from([])

--- a/tests_zemu/tests/arbitrary_sign.test.ts
+++ b/tests_zemu/tests/arbitrary_sign.test.ts
@@ -80,8 +80,7 @@ describe('Arbitrary Sign', function () {
 
 
         // Now verify the signature
-        const prehash = Buffer.concat([Buffer.from('TX'), toSign])
-        const valid = ed25519.verify(signatureResponse.signature, prehash, pubKey)
+        const valid = ed25519.verify(signatureResponse.signature, toSign, pubKey)
         expect(valid).toEqual(true)
       } finally {
         await sim.close()


### PR DESCRIPTION
'TX' prefix should only be prepended to the preimage when dealing with transactions.