### PR TITLE
Increase JSMN token capacity to 650

### DIFF
--- a/app/src/json/parser_json.h
+++ b/app/src/json/parser_json.h
@@ -17,7 +17,7 @@
 
 #include "jsmn.h"
 
-#define MAX_NUMBER_OF_JSMN_TOKENS 80
+#define MAX_NUMBER_OF_JSMN_TOKENS 600
 
 typedef struct {
     jsmntok_t *tokens;

--- a/tests_zemu/tests/common.ts
+++ b/tests_zemu/tests/common.ts
@@ -5,7 +5,6 @@ import { resolve } from 'path'
 export const APP_SEED =
   'glory promote mansion idle axis finger extra february uncover one trip resource lawn turtle enact monster seven myth punch hobby comfort wild raise skin'
 
-const APP_PATH_S = resolve('../app/output/app_s.elf')
 const APP_PATH_X = resolve('../app/output/app_x.elf')
 const APP_PATH_SP = resolve('../app/output/app_s2.elf')
 const APP_PATH_ST = resolve('../app/output/app_stax.elf')


### PR DESCRIPTION
- Tried some limits until this upper bound was hit.

As shown in the map file, the size of `t` is now 0x2580 (9600) bytes :
```
    VMA      LMA     Size    Align
...
da7a2270 da7a2270       14     4         build/nanox/obj/app/app/src/crypto.o:(.bss.hdPath)
da7a2270 da7a2270       14     1                 hdPath
da7a2284 da7a2284     2580     4         build/nanox/obj/app/app/src/json/parser_json.o:(.bss.t)
da7a2284 da7a2284     2580     1                 t
```