### PR TITLE
Feat/extend test vectors

### DIFF
--- a/tests_zemu/package.json
+++ b/tests_zemu/package.json
@@ -26,10 +26,12 @@
     "@zondax/ledger-algorand": "../js",
     "@zondax/zemu": "^0.55.3",
     "algosdk": "^3.2.0",
+    "cbor": "^10.0.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.29.5",
+    "@truestamp/canonify": "^2.1.0",
     "@types/ledgerhq__hw-transport": "^6.0.0",
     "@types/node": "^20.11.0",
     "@types/yargs": "^17.0.32",
@@ -45,7 +47,6 @@
     "jssha": "^3.3.1",
     "prettier": "^3.5.3",
     "ts-node": "^10.9.2",
-    "@truestamp/canonify": "^2.1.0",
     "typescript": "^5.8.2",
     "vitest": "^1.6.1"
   }

--- a/tests_zemu/test_vec_generator/caip122.ts
+++ b/tests_zemu/test_vec_generator/caip122.ts
@@ -102,7 +102,8 @@ class Caip122Generator extends ProtocolGenerator {
 
           // Get all possible additional field combinations
           const requestId = this.generateRequestId();
-          const { fieldCombinations } = generateCommonAdditionalFields(domain, pubkey, hdPath, requestId);
+          const authData = crypto.createHash('sha256').update(domain).digest('hex');
+          const { fieldCombinations } = generateCommonAdditionalFields(domain, authData, pubkey, hdPath, requestId);
           
           // Domain in CAIP-122 options
           for (const includeDomainInCaip122 of [true, false]) {

--- a/tests_zemu/test_vec_generator/common.ts
+++ b/tests_zemu/test_vec_generator/common.ts
@@ -346,18 +346,18 @@ export const FIELD_NAMES = {
 // Function to generate all possible combinations of common additional fields
 export function generateCommonAdditionalFields(
   domain: string,
+  authData: string,
   pubkey: string,
   hdPath: string,
   requestId?: string
 ): { fieldCombinations: { fields: Field[]}[] } {
-  const crypto = require('crypto');
-  const authData = crypto.createHash('sha256').update(domain).digest('hex');
   const signer = generateAlgorandAddress(pubkey);
 
   // Create deterministic request ID if not provided
   if (!requestId) {
     // Replace random generation with deterministic seeded generation
     const input = `${COMMON_RANDOMNESS_SEED}-${domain}-${pubkey}`;
+    const crypto = require('crypto');
     const hash = crypto.createHash('sha256').update(input).digest('HEX');
     requestId = hash.substring(0, 32).toUpperCase();
   }
@@ -431,6 +431,10 @@ export class RandomGenerator {
       result += charset.charAt(randomIndex);
     }
     return result;
+  }
+
+  generateRandomNumber(min: number, max: number, purposePrefix: string): number {
+    return Math.floor(this.getSeededRandom(`${purposePrefix}-${min}-${max}`) * (max - min + 1)) + min;
   }
 }
 

--- a/tests_zemu/test_vec_generator/fido2.ts
+++ b/tests_zemu/test_vec_generator/fido2.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto';
+import * as cbor from 'cbor';
 import { 
   determineVectorValidity,
   Field, 
@@ -43,11 +44,117 @@ class Fido2Generator extends ProtocolGenerator {
     insertFieldAlphabetically(fields, { name: "origin", value: origin });
     return fields;
   }
+
+  private generateAuthDataValues(domain: string): string[] {
+    /*
+    https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data
+
+    rpIdHash
+    flags
+    signCount
+    aaguid
+    credentialIdLength
+    credentialId
+    credentialPublicKey
+    extensions
+    */
+
+    const bitValues = [false, true];
+
+    var flags: number = 0;
+
+    const authDataValues: string[] = [];
+
+    const rpIdHash: Buffer = Buffer.from(crypto.createHash('sha256').update(domain).digest('hex'), 'hex');
+
+    for (const up of bitValues) {
+      for (const uv of bitValues) {
+        for (const at of bitValues) {
+          for (const ed of bitValues) {
+            if (up) {
+              flags = flags | 0b00000001
+            }
+            if (uv) {
+              flags = flags | 0b00000100
+            }
+            if (at) {
+              flags = flags | 0b01000000
+            }
+            if (ed) {
+              flags = flags | 0b10000000
+            }
+
+            const signCount = this.randomGenerator.generateRandomNumber(0, 2**32 - 1, 'signCount');
+            const aaguid: Buffer = this.randomGenerator.generateRandomBytes(16, 'aaguid');
+            const credentialId: Buffer = this.randomGenerator.generateRandomBytes(16, 'credentialId');
+            const credentialIdLength = credentialId.length;
+            const credentialPublicKey = {
+              kty: 2,
+              alg: -7,
+              crv: 1,
+              x: this.randomGenerator.generateRandomBytes(32, 'credPubKeyX'),
+              y: this.randomGenerator.generateRandomBytes(32, 'credPubKeyY')
+            };
+            const credentialPublicKeyBuffer: Buffer = cbor.encode(credentialPublicKey);
+            const extensions: Buffer = this.createExtensionsCBOR();
+
+            var authDataLength = rpIdHash.length + 1 + 4
+
+            if (at) {
+              authDataLength += aaguid.length + 2 + credentialIdLength + credentialPublicKeyBuffer.length;
+            }
+            if (ed) {
+              authDataLength += extensions.length;
+            }
+
+            const authData: Buffer = Buffer.alloc(authDataLength);
+
+            var offset = 0;
+            rpIdHash.copy(authData, offset);
+            offset += rpIdHash.length;
+            authData.writeUInt8(flags, offset);
+            offset += 1;
+            authData.writeUInt32LE(signCount, offset);
+            offset += 4;
+
+            if (at) {
+              aaguid.copy(authData, offset);
+              offset += aaguid.length;
+              authData.writeUInt16LE(credentialIdLength, offset);
+              offset += 2;
+              credentialId.copy(authData, offset);
+              offset += credentialId.length;
+              credentialPublicKeyBuffer.copy(authData, offset);
+              offset += credentialPublicKeyBuffer.length;
+            }
+
+            if (ed) {
+              extensions.copy(authData, offset);
+            }
+
+            authDataValues.push(authData.toString('hex'));
+          }
+        }
+      }
+    }
+
+    return authDataValues;
+  }
   
-  private createExtensions(): string {
+  private createExtensionsCBOR(): Buffer {
     const extensions = {
-      credProps: true,
-      exampleExt: "test-value"
+      booleanExt: true,
+      numericExt: 42,
+      stringExt: "test-value"
+    };
+    return cbor.encode(extensions);
+  }
+
+  private createExtensionsString(): string {
+    const extensions = {
+      booleanExt: true,
+      numericExt: 42,
+      stringExt: "test-value"
     };
     return JSON.stringify(extensions);
   }
@@ -76,63 +183,68 @@ class Fido2Generator extends ProtocolGenerator {
       for (const pubkeyHdPathPair of pubkeyHdPathPairs) {
         const pubkey = pubkeyHdPathPair.pubkey;
         const hdPath = pubkeyHdPathPair.hdPath;
+
+        const authDataValues = this.generateAuthDataValues(domain);
+
+        for (const authData of authDataValues) {
         
-        // Get all possible additional field combinations
-        const { fieldCombinations } = generateCommonAdditionalFields(domain, pubkey, hdPath);
-        
-        // Request type options
-        for (const includeType of [true, false]) {
-          for (const requestType of includeType ? requestTypes : [null]) {
-            // RpId options
-            for (const includeRpId of [true, false]) {
-              // UserId options
-              for (const includeUserId of [true, false]) {
-                // Extensions options
-                for (const includeExtensions of [true, false]) {
-                  // Iterate through all additional field combinations
-                  for (const { fields: additionalFields } of fieldCombinations) {
-                    this.chosenPubkeys.push(pubkey);
+          // Get all possible additional field combinations
+          const { fieldCombinations } = generateCommonAdditionalFields(domain, authData, pubkey, hdPath);
+          
+          // Request type options
+          for (const includeType of [true, false]) {
+            for (const requestType of includeType ? requestTypes : [null]) {
+              // RpId options
+              for (const includeRpId of [true, false]) {
+                // UserId options
+                for (const includeUserId of [true, false]) {
+                  // Extensions options
+                  for (const includeExtensions of [true, false]) {
+                    // Iterate through all additional field combinations
+                    for (const { fields: additionalFields } of fieldCombinations) {
+                      this.chosenPubkeys.push(pubkey);
 
-                    const challenge = this.generateChallenge();
-                    const userId = this.generateUserId();
-                    
-                    // Create base fields for FIDO2 request
-                    const fido2Fields = this.createBaseFido2Fields(origin, challenge);
-                    
-                    // Add optional fields based on the combination
-                    if (includeType && requestType) {
-                      insertFieldAlphabetically(fido2Fields, { name: "type", value: requestType });
-                    }
-                    
-                    if (includeRpId) {
-                      insertFieldAlphabetically(fido2Fields, { name: "rpId", value: domain });
-                    }
-                    
-                    if (includeUserId) {
-                      insertFieldAlphabetically(fido2Fields, { name: "userId", value: userId });
-                    }
+                      const challenge = this.generateChallenge();
+                      const userId = this.generateUserId();
+                      
+                      // Create base fields for FIDO2 request
+                      const fido2Fields = this.createBaseFido2Fields(origin, challenge);
+                      
+                      // Add optional fields based on the combination
+                      if (includeType && requestType) {
+                        insertFieldAlphabetically(fido2Fields, { name: "type", value: requestType });
+                      }
+                      
+                      if (includeRpId) {
+                        insertFieldAlphabetically(fido2Fields, { name: "rpId", value: domain });
+                      }
+                      
+                      if (includeUserId) {
+                        insertFieldAlphabetically(fido2Fields, { name: "userId", value: userId });
+                      }
 
-                    if (includeExtensions) {
-                      insertFieldAlphabetically(fido2Fields, { name: "extensions", value: this.createExtensions() });
-                    }
-                    
-                    if (determineVectorValidity(fido2Fields, additionalFields) == false) {
-                      throw new Error("Invalid config generated");
-                    }
+                      if (includeExtensions) {
+                        insertFieldAlphabetically(fido2Fields, { name: "extensions", value: this.createExtensionsString() });
+                      }
+                      
+                      if (determineVectorValidity(fido2Fields, additionalFields) == false) {
+                        throw new Error("Invalid config generated");
+                      }
 
-                    // Combine all fields
-                    const fields = [...fido2Fields, ...additionalFields];
+                      // Combine all fields
+                      const fields = [...fido2Fields, ...additionalFields];
 
-                    // Create configuration
-                    const config = {
-                      index: index,
-                      name: `Algorand_FIDO2_${index}`,
-                      fields: fields,
-                      error: "No error"
-                    };
-                    
-                    configs.push(config);
-                    index++;
+                      // Create configuration
+                      const config = {
+                        index: index,
+                        name: `Algorand_FIDO2_${index}`,
+                        fields: fields,
+                        error: "No error"
+                      };
+                      
+                      configs.push(config);
+                      index++;
+                    }
                   }
                 }
               }


### PR DESCRIPTION
Extended test vectors so that there are FIDO requests with complete Authenticator Data fields.
Authenticator Data spec : https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data
Algorand's arbitrary sign spec : https://github.com/ehanoc/ARCs/blob/41c3047b3805fd2478c97de3b6c101a61ef4fa9c/ARCs/arc-0060.md#authenticatordata